### PR TITLE
fix of windows build

### DIFF
--- a/lib/src/fasttext.cc
+++ b/lib/src/fasttext.cc
@@ -19,6 +19,7 @@
 #include <vector>
 #include <queue>
 #include <algorithm>
+#include <numeric>
 
 
 namespace fasttext {

--- a/lib/src/productquantizer.cc
+++ b/lib/src/productquantizer.cc
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <numeric>
 
 namespace fasttext {
 


### PR DESCRIPTION
I'm getting two errors in time of build:

```
error C2039: 'iota': is not a member of 'std' 
error C3861: 'iota': identifier not found
```
Adding following line to the files using std::iota helped:
`#include <numeric>`

I have found the solution here: http://www.programmingforums.org/thread7858.html